### PR TITLE
Fix TabStats

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -1,6 +1,6 @@
 commitizen:
   name: cz_conventional_commits
   tag_format: v$version
-  version: 0.7.3
+  version: 0.7.4
   version_files:
   - constants/constants.go:VERSION    string

--- a/metrics/ranked_tabstats.go
+++ b/metrics/ranked_tabstats.go
@@ -26,7 +26,7 @@ type rankedTabStats struct {
 const tabStatsBaseURL = "https://r6.apitab.net/website/profiles/"
 
 func getRankedTabStats(profile *r6api.Profile) (result *rankedTabStats, err error) {
-	requestURL := tabStatsBaseURL + profile.ProfileID + "?update=false"
+	requestURL := tabStatsBaseURL + profile.ProfileID + "?update=true"
 	req, _ := http.NewRequest("GET", requestURL, nil)
 	req.Header.Add("User-Agent", constants.USER_AGENT)
 	req.Header.Add("Accept", "application/json")


### PR DESCRIPTION
We had `update=false` as query parameter for TabStats to avoid additional overhead on their side.
Turns out this means that we will get outdated data from their API, so we do need to set `update=true`.